### PR TITLE
Enable visual styles for native controls on windows

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -49,6 +49,9 @@ extern "C" int LZ4_decompress_safe(const char *source, char *dest, int compresse
 #ifdef KORE_WINDOWS
 #include <Windows.h> // AttachConsole
 extern "C" { struct HWND__ *kinc_windows_window_handle(int window_index); } // Kore/Windows.h
+
+//Enable visual styles for controls.
+#pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 #endif
 
 #ifdef WITH_D3DCOMPILER


### PR DESCRIPTION
Armorpaint's visual look is very good. Unfortunately the windows "Do you want to save changes"-dialog looks like Windows 95 and I think ArmorPaint deserves something better. It's just a small cosmetic change to tell the linker to enable the visual styles. Feel free to not accept it if you have other plans like implementing a platform independet solution for it.