### PR TITLE
Add windowId parameter to Krom.setMousePosition()

### DIFF
--- a/Sources/Krom.hx
+++ b/Sources/Krom.hx
@@ -104,7 +104,7 @@ extern class Krom {
 	static function unlockMouse(): Void;
 	static function canLockMouse(): Bool;
 	static function isMouseLocked(): Bool;
-	static function setMousePosition(x: Int, y: Int): Void;
+	static function setMousePosition(windowId: Int, x: Int, y: Int): Void;
 	static function showMouse(show: Bool): Void;
 	static function showKeyboard(show: Bool): Void;
 	static function setAudioCallback(callback: Int->Void): Void;

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -561,9 +561,10 @@ namespace {
 
 	void krom_set_mouse_position(const FunctionCallbackInfo<Value> &args) {
 		HandleScope scope(args.GetIsolate());
-		int x = args[0]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
-		int y = args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
-		kinc_mouse_set_position(0, x, y);
+		int windowId = args[0]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
+		int x = args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
+		int y = args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
+		kinc_mouse_set_position(windowId, x, y);
 	}
 
 	void krom_show_mouse(const FunctionCallbackInfo<Value> &args) {


### PR DESCRIPTION
As discussed in https://github.com/Kode/Krom/pull/144. I couldn't find any usages of `Krom.setMousePosition()` in any armory3d project so it should be safe to break compatibility here for API parity with Kode/Krom.

Because I'm still confused about what Krom version Armory uses right now: would it make sense to add `setMousePosition()` to https://github.com/armory3d/Kha/blob/master/Backends/Krom/Krom.hx after the next binary update?