### PR TITLE
Hide hidden files in Browser on Windows

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2697,6 +2697,7 @@ namespace {
 
 			if (!file.is_dir || !foldersOnly) {
 				#ifdef KORE_WINDOWS
+				if (FILE_ATTRIBUTE_HIDDEN & GetFileAttributesW(file.path)) continue; //skip hidden files
 				if (wcscmp(file.name, L".") == 0 || wcscmp(file.name, L"..") == 0) continue;
 				if (wcslen(temp_wstring) + wcslen(file.name) + 1 > 1023) break;
 				wcscat(temp_wstring, file.name);


### PR DESCRIPTION
Currently the ArmorPaint browser shows hidden files and folders on Windows, too. This could confuse users who see folders they have never heard of and make browsing unnecessarily complicated (I mean who would want to store assets in hidden folders).
I solved this by excluding hidden files in krom_read_directory. This has several implications:
1. hidden files and folders do not show up in the Browser anymore
2. All other procedures that use File.readDirectory will not find hidden files and folders, too. In theory this could break something but I doubt it will. Even if the directory to browse is a hidden one its children are probably not e.g. the subdirectories of AppData.

If you dislike the current restrictive behavior but follow my idea that the Browser should not show these files please tell me. In this case I will add a parameter to enable/disable enumeration of hidden files and hide it for the Browser tab.