### PR TITLE
Make file open/save modal on windows

### DIFF
--- a/Libraries/nfd/nfd_win.cpp
+++ b/Libraries/nfd/nfd_win.cpp
@@ -27,6 +27,8 @@
 #include <shobjidl.h>
 #include "nfd_common.h"
 
+extern "C" { struct HWND__* kinc_windows_window_handle(int window_index); } // Kore/Windows.h
+
 
 #define COM_INITFLAGS ::COINIT_APARTMENTTHREADED | ::COINIT_DISABLE_OLE1DDE
 
@@ -423,7 +425,7 @@ nfdresult_t NFD_OpenDialog( const nfdchar_t *filterList,
     }    
 
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(kinc_windows_window_handle(0));
     if ( SUCCEEDED(result) )
     {
         // Get the file name
@@ -529,7 +531,7 @@ nfdresult_t NFD_OpenDialogMultiple( const nfdchar_t *filterList,
     }
  
     // Show the dialog.
-    result = fileOpenDialog->Show(NULL);
+    result = fileOpenDialog->Show(kinc_windows_window_handle(0));
     if ( SUCCEEDED(result) )
     {
         IShellItemArray *shellItems;


### PR DESCRIPTION
The file open/save dialog is not a child window of the main window but an additional window. That is no typical behavior for a program and it is much more convenient if these dialogs are children of the main window.
Unfortunately I could not find an elegant solution to this issue. Therefore I modified the nfd library accordingly. Clearly this is not the best idea to have (even though the modification itself is very simple) so feel free to not accept this PR. Imho the modification is ok in this case because the library itself is hardly maintained and reapplying this modification on any update should be pretty straight forward. As an alternative I could create a patch that modifies the sources. Maybe this is a better solution.