### PR TITLE
Fix memory leak when using web workers

### DIFF
--- a/Sources/worker.cpp
+++ b/Sources/worker.cpp
@@ -90,6 +90,7 @@ namespace {
 			return;
 		}
 
+		HandleScope scope(isolate);
 		Local<Context> current_context = Local<Context>::New(isolate, context);
 		Context::Scope context_scope(current_context);
 


### PR DESCRIPTION
This fixes https://github.com/armory3d/armorcore/issues/58 (confirmed on Discord by @ QuantumCoderQC), although I'm not sure whether there are better solutions for it.

As you can see in the linked issue, the local context that gets allocated in `handle_message_queue()` wasn't that local despite suggested by its type. Perhaps it is possible to not allocate a context each frame, but I don't know much about V8 internals, so for now I think this fix will do.