### PR TITLE
Fix crash caused by freeing internal V8 BackingStore memory

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2037,12 +2037,14 @@ namespace {
 		std::shared_ptr<BackingStore> content = buffer->GetBackingStore();
 		kinc_g4_texture_t *texture = (kinc_g4_texture_t *)malloc(sizeof(kinc_g4_texture_t));
 		kinc_image_t *image = (kinc_image_t *)malloc(sizeof(kinc_image_t));
-		kinc_image_init(image, content->Data(), args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
+		void* imageData = malloc(content->ByteLength());
+		memcpy(imageData, content->Data(), content->ByteLength());
+		kinc_image_init(image, imageData, args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
 		kinc_g4_texture_init_from_image(texture, image);
 		bool readable = args[4]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
 		if (!readable) {
-			delete[] content->Data();
 			kinc_image_destroy(image);
+			free(imageData);
 			free(image);
 		}
 

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2037,14 +2037,14 @@ namespace {
 		std::shared_ptr<BackingStore> content = buffer->GetBackingStore();
 		kinc_g4_texture_t *texture = (kinc_g4_texture_t *)malloc(sizeof(kinc_g4_texture_t));
 		kinc_image_t *image = (kinc_image_t *)malloc(sizeof(kinc_image_t));
-		void* imageData = malloc(content->ByteLength());
-		memcpy(imageData, content->Data(), content->ByteLength());
-		kinc_image_init(image, imageData, args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
+		void *image_data = malloc(content->ByteLength());
+		memcpy(image_data, content->Data(), content->ByteLength());
+		kinc_image_init(image, image_data, args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
 		kinc_g4_texture_init_from_image(texture, image);
 		bool readable = args[4]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
 		if (!readable) {
 			kinc_image_destroy(image);
-			free(imageData);
+			free(image_data);
 			free(image);
 		}
 
@@ -2068,12 +2068,14 @@ namespace {
 		std::shared_ptr<BackingStore> content = buffer->GetBackingStore();
 		kinc_g4_texture_t *texture = (kinc_g4_texture_t *)malloc(sizeof(kinc_g4_texture_t));
 		kinc_image_t image;
-		kinc_image_init3d(&image, content->Data(), args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[4]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
+		void *image_data = malloc(content->ByteLength());
+		memcpy(image_data, content->Data(), content->ByteLength());
+		kinc_image_init3d(&image, image_data, args[1]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[2]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), args[3]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value(), (kinc_image_format_t)args[4]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value());
 		kinc_g4_texture_init_from_image3d(texture, &image);
 		kinc_image_destroy(&image);
 		bool readable = args[5]->ToInt32(isolate->GetCurrentContext()).ToLocalChecked()->Value();
 		if (!readable) {
-			delete[] content->Data();
+			free(image_data);
 		}
 
 		Local<ObjectTemplate> templ = ObjectTemplate::New(isolate);


### PR DESCRIPTION
This PR fixes a crash that would happen in random places after `krom_create_texture_from_bytes()` was called.

According to [this document](https://docs.google.com/document/d/1sTc_jRL87Fu175Holm5SV0kajkseGl2r8ifGY76G35k) which I found [here](https://bugs.chromium.org/p/v8/issues/detail?id=9908) (linked from the `BackingStore` docstring), references to `BackingStore` objects have to be managed via shared pointers that automatically free the backing store memory when the last reference is removed. Since `krom_create_texture_from_bytes()` manually freed the backing store data if the image was not set to be readable, there would be a crash later on when V8 attempted to free the memory, for example when the Haxe array to which the backing store corresponded got GC'd. I guess similar issues would happen if the array was accessed again from Haxe.

This was quite difficult to find, since there were a dozen or so different stack traces of the crash that were completely different every time the crash occured and the crash happened in various different background threads. I guess this was due to the fact that the time at which the last reference from the backing store gets removed varies a lot in V8. Luckily there was one stack trace that actually contained an entry for the BackingStore destructor:

```
 	ntdll.dll!RtlReportCriticalFailure()	Unbekannt
 	ntdll.dll!RtlpHeapHandleError()	Unbekannt
 	ntdll.dll!RtlpHpHeapHandleError()	Unbekannt
 	ntdll.dll!RtlpLogHeapFailure()	Unbekannt
 	ntdll.dll!RtlpFreeHeapInternal()	Unbekannt
 	ntdll.dll!RtlFreeHeap()	Unbekannt
>	Armory.exe!_free_base(void * block) Zeile 105	C++
 	Armory.exe!v8::internal::BackingStore::~BackingStore(void)	C++
 	Armory.exe!std::_Ref_count_resource<class v8::internal::BackingStore *,struct std::default_delete<class v8::internal::BackingStore> >::_Destroy(void)	C++
 	Armory.exe!v8::internal::ArrayBufferSweeper::SweepingJob::SweepYoung(void)	C++
 	Armory.exe!v8::internal::ArrayBufferSweeper::SweepingJob::Sweep(void)	C++
 	Armory.exe!v8::internal::ArrayBufferSweeper::~ArrayBufferSweeper(void)	C++
 	Armory.exe!v8::internal::CancelableTask::Run(void)	C++
 	Armory.exe!v8::platform::DefaultWorkerThreadsTaskRunner::WorkerThread::Run(void)	C++
 	Armory.exe!v8::base::OS::StrNCpy(char *,int,char const *,unsigned __int64)	C++
 	Armory.exe!thread_start<unsigned int (__cdecl*)(void *),1>(void * const parameter) Zeile 97	C++
 	kernel32.dll!BaseThreadInitThunk()	Unbekannt
 	ntdll.dll!RtlUserThreadStart()	Unbekannt
```

After noticing this, it was rather easy to find the cause, given the fact that I was able to reproduce the crash every time an Armory scene with the Nishita sky model was used, [which calls `kha.Image.fromBytes()`](https://github.com/armory3d/armory/blob/6bffcd8be4df95e43895b33a17c1d34042db1ec3/Sources/armory/renderpath/Nishita.hx#L169).

Due to https://github.com/armory3d/armorcore/issues/63 I wasn't able to test my fix with the latest Armorcore main branch but with https://github.com/armory3d/armorcore/commit/93b696f380869fe3e73ba4c2e4c7663de8452fab, it should still work with newer versions though :)

**Edit**: also fixed this for `krom_create_texture_from_bytes3d()`. There could be some more misuses of backing stores, but the other usages look correct to me (though I still understand too little of the Armorcore and Kinc code in order to be certain here).