### PR TITLE
Implement `kha.Image.stride` attribute

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -2224,11 +2224,15 @@ namespace {
 
 	void krom_lock_texture(const FunctionCallbackInfo<Value> &args) {
 		HandleScope scope(args.GetIsolate());
-		Local<External> field = Local<External>::Cast(args[0]->ToObject(isolate->GetCurrentContext()).ToLocalChecked()->GetInternalField(0));
+		Local<Object> textureobj = args[0]->ToObject(isolate->GetCurrentContext()).ToLocalChecked();
+		Local<External> field = Local<External>::Cast(textureobj->GetInternalField(0));
 		kinc_g4_texture_t *texture = (kinc_g4_texture_t *)field->Value();
 		uint8_t *tex = kinc_g4_texture_lock(texture);
 
-		int byteLength = kinc_g4_texture_stride(texture) * texture->tex_height * texture->tex_depth;
+		int stride = kinc_g4_texture_stride(texture);
+		(void) textureobj->Set(isolate->GetCurrentContext(), String::NewFromUtf8(isolate, "stride").ToLocalChecked(), Int32::New(isolate, stride));
+
+		int byteLength = stride * texture->tex_height * texture->tex_depth;
 		std::unique_ptr<v8::BackingStore> backing = v8::ArrayBuffer::NewBackingStore((void *)tex, byteLength, [](void *, size_t, void *) {}, nullptr);
 		Local<ArrayBuffer> abuffer = ArrayBuffer::New(isolate, std::move(backing));
 		args.GetReturnValue().Set(abuffer);


### PR DESCRIPTION
This PR is one part of the fix for https://github.com/armory3d/armory/issues/2026, the other part is a change in Kha for which I cannot open a pull request yet because of https://github.com/armory3d/armorcore/issues/63: the Kha change would require this PR and we can't update Armorcore for Armory at the moment due to the linked issue. As a consequence, the fixed Kha code would not be able to access the texture stride and thus Armory wouldn't render text at all once Armory's Kha version is updated. Currently, only AMD GPUs seem to be affected by the text rendering issue, so no text at all would be clearly worse than the current situation.

For the same reason as above I could only test this code based on 93b696f380869fe3e73ba4c2e4c7663de8452fab, the last working commit for Armory.