### PR TITLE
Fix for https://github.com/armory3d/armorcore/issues/73

### DIFF
--- a/Sources/iron/iron_string.c
+++ b/Sources/iron/iron_string.c
@@ -1,6 +1,11 @@
 #include "iron_string.h"
 
-#include <malloc.h>
+#if defined __APPLE__
+    #import <stdlib.h>
+#else
+    #include <malloc.h>
+#endif
+
 #include <string.h>
 
 void string_init(string_t *s, const char *str) {


### PR DESCRIPTION
On my machine at least, macOS expects import `stdlib` instead of `malloc` directly.