### PR TITLE
Fix crash on saving in armorpaint

### DIFF
--- a/Sources/iron/armpack.ts
+++ b/Sources/iron/armpack.ts
@@ -272,7 +272,7 @@ function armpack_write_object(v: DataView, d: any) {
 }
 
 function armpack_write_dummy(d: any) {
-	if (typeof d == null) {
+	if (d == null) {
 		_armpack_pos += 1;
 	}
 	else if (typeof d == "boolean") {


### PR DESCRIPTION
Armorpaint was locking up for me on linux every time I saved, producing and endless series of these messages:

```
Trace: TypeError: Cannot read properties of null (reading 'constructor')
    at armpack_write_dummy (<anonymous>:1818:16)
    at armpack_write_object_dummy (<anonymous>:1870:9)
    at armpack_write_dummy (<anonymous>:1859:9)
    at armpack_encode (<anonymous>:1691:5)
    at ExportArm.runProject (<anonymous>:13610:18)
    at _init (<anonymous>:12319:19)
    at app_update (<anonymous>:1403:21)
    at app_render (<anonymous>:1443:5)
    at sys_render_callback (<anonymous>:5894:9)
```

This seemed to fix it.