### PR TITLE
Fix UT8 handling in fs_writefile

### DIFF
--- a/tools/make.js
+++ b/tools/make.js
@@ -79,11 +79,40 @@ function fs_readfile(p) {
 	return std.loadFile(p);
 }
 
+// Modification of https://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+function toUInt8Array(str) {
+    let utf8 = [];
+    for (let i=0; i < str.length; i++) {
+        let charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+            utf8.push(0xc0 | (charcode >> 6), 
+                      0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+            utf8.push(0xe0 | (charcode >> 12), 
+                      0x80 | ((charcode>>6) & 0x3f), 
+                      0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+            i++;
+            // UTF-16 encodes 0x10000-0x10FFFF by
+            // subtracting 0x10000 and splitting the
+            // 20 bits of 0x0-0xFFFFF into two halves
+            charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+                      | (str.charCodeAt(i) & 0x3ff));
+            utf8.push(0xf0 | (charcode >>18), 
+                      0x80 | ((charcode>>12) & 0x3f), 
+                      0x80 | ((charcode>>6) & 0x3f), 
+                      0x80 | (charcode & 0x3f));
+        }
+    }
+    return new Uint8Array(utf8);
+}
+
 function fs_writefile(p, data) {
-	let u8 = new Uint8Array(data.length);
-	for (let i = 0; i < data.length; ++i) {
-		u8[i] = data.charCodeAt(i);
-	}
+	let u8 = toUInt8Array(data);
 	let f = std.open(p, "w");
 	f.write(u8.buffer, 0, u8.length);
 	f.close();


### PR DESCRIPTION
Fixes #1768 Thanks to @shiena s investigation it was easy to see that non ascii utf8 glyphs where handled incorrectly because they take more than one byte. `charCodeAt` retrieves a utf16 code point though because JavaScript stores string in utf16 encoding internally. Therefore the solution to convert to utf8 first.